### PR TITLE
Format timestamp using the moment module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "http://npm.trippnology.net:4873/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "node-getopt": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jasmine": "^2.5.3"
   },
   "dependencies": {
+    "moment": "2.24.0",
     "node-getopt": "^0.2.3",
     "utils-for-aprs": "^2.2.10"
   }

--- a/watch-aprs.js
+++ b/watch-aprs.js
@@ -60,7 +60,7 @@ var aprsProcessor=new APRSProcessor();
 aprsProcessor.on('aprsData', function(frame) {
   frame.receivedAt=moment().format();
 
-  console.log( "[" + frame.receivedAt + "]" + ax25utils.addressToString(frame.source) +
+  console.log( "[" + frame.receivedAt + "] " + ax25utils.addressToString(frame.source) +
     '->' + ax25utils.addressToString(frame.destination) +
     ' (' + ax25utils.repeaterPathToString(frame.repeaterPath) + ')' +
     ((frame.forwardingSource!=undefined)?(

--- a/watch-aprs.js
+++ b/watch-aprs.js
@@ -29,6 +29,7 @@ var util=require('util');
 var ax25utils=require('utils-for-aprs').ax25utils;
 var SocketKISSFrameEndpoint=require('utils-for-aprs').SocketKISSFrameEndpoint;
 var APRSProcessor=require('utils-for-aprs').APRSProcessor;
+var moment = require('moment');
 
 console.log("process.argv=" + process.argv);
 
@@ -57,7 +58,7 @@ var aprsProcessor=new APRSProcessor();
 
 // When we get data on the aprsProcessor, show it on the console.
 aprsProcessor.on('aprsData', function(frame) {
-  frame.receivedAt=new Date();
+  frame.receivedAt=moment().format();
 
   console.log( "[" + frame.receivedAt + "]" + ax25utils.addressToString(frame.source) +
     '->' + ax25utils.addressToString(frame.destination) +


### PR DESCRIPTION
Hi, thanks for this module (and the "parent" module `utils-for-aprs`), it's useful for debugging or just monitoring, but I found the timestamps to take up too much room.

I'm formatting the timestamp with the [moment](https://momentjs.com/) module, which is probably overkill, but meant this was just a 2 line change.

Thought I would submit the change back to you, in case you found it useful.